### PR TITLE
Fix: Resolve CacheService dependency injection error

### DIFF
--- a/src/redis/redis.module.ts
+++ b/src/redis/redis.module.ts
@@ -1,11 +1,12 @@
 import { Module, Global } from '@nestjs/common';
 import { RedisService } from './redis.service';
 import { RedisTestController } from './redis.controller';
+import { CacheService } from '../common/services/cache.service';
 
-@Global() // Makes RedisService available everywhere without importing
+@Global() // Makes RedisService and CacheService available everywhere without importing
 @Module({
   controllers: [RedisTestController],
-  providers: [RedisService],
-  exports: [RedisService],
+  providers: [RedisService, CacheService],
+  exports: [RedisService, CacheService],
 })
 export class RedisModule {}


### PR DESCRIPTION
## Problem
The application was failing to start with the following error:
```
Nest can't resolve dependencies of the HealthController (?). Please make sure that the argument CacheService at index [0] is available in the HealthModule context.
```

## Root Cause
The `HealthController` was trying to inject `CacheService`, but `CacheService` wasn't provided in any module that's imported by `HealthModule`. While `RedisModule` was imported, it only exported `RedisService`, not `CacheService`.

## Solution
Added `CacheService` to the `RedisModule` providers and exports since:
1. `CacheService` depends on `RedisService`
2. `RedisModule` is already marked as `@Global()`
3. This makes `CacheService` available throughout the application without additional imports

## Changes
- Updated `src/redis/redis.module.ts` to include `CacheService` in providers and exports
- Added proper import for `CacheService` from `../common/services/cache.service`

## Testing
After this change, the application should start successfully without dependency injection errors.

## Alternative Approaches Considered
1. **Create a CommonModule**: Would require importing it in every module that needs `CacheService`
2. **Add CacheService to HealthModule directly**: Would only make it available in that module
3. **Current approach**: Leverages the existing global `RedisModule` structure

The current approach is the most maintainable as it keeps related services together and leverages the existing global module pattern.